### PR TITLE
Maven/steganography

### DIFF
--- a/guarddog/analyzer/sourcecode/maven-steganography.yml
+++ b/guarddog/analyzer/sourcecode/maven-steganography.yml
@@ -5,11 +5,22 @@ rules:
     message: This package is dynamically executing hidden data from an image
     metadata:
       description: Identify when a package retrieves hidden data from an image and executes it
-    patterns:
-      - pattern-inside: |
-          import io.github.galliumdata.adumbra;
-          ...
-          $ENC = new Encoder(...);
-          ...
-      - pattern: $ENC.encode(...)
+    pattern-either:
+      - patterns: 
+        # adumbra library
+        - pattern-inside: |
+            import io.github.galliumdata.adumbra;
+            ...
+            $ENC = new Encoder(...);
+            ...
+        - pattern: $ENC.encode(...)
+       # tigerlyb Steganography-in-Java 
+      - patterns: 
+        - pattern: Steganography.$EMBED(...)
+        - metavariable-regex:
+            metavariable: $EMBED
+            regex: embed.*
+      # ImageHandle.Steganography
+      - pattern: new Steganography(...)
+
     severity: WARNING

--- a/guarddog/analyzer/sourcecode/maven-steganography.yml
+++ b/guarddog/analyzer/sourcecode/maven-steganography.yml
@@ -1,0 +1,15 @@
+rules:
+  - id: maven-steganography
+    languages:
+      - java
+    message: This package is dynamically executing hidden data from an image
+    metadata:
+      description: Identify when a package retrieves hidden data from an image and executes it
+    patterns:
+      - pattern-inside: |
+          import io.github.galliumdata.adumbra;
+          ...
+          $ENC = new Encoder(...);
+          ...
+      - pattern: $ENC.encode(...)
+    severity: WARNING

--- a/guarddog/analyzer/sourcecode/maven-steganography.yml
+++ b/guarddog/analyzer/sourcecode/maven-steganography.yml
@@ -20,7 +20,14 @@ rules:
         - metavariable-regex:
             metavariable: $EMBED
             regex: embed.*
-      # ImageHandle.Steganography
-      - pattern: new Steganography(...)
+      # ImageHandle.Steganography and other custom classes
+      - patterns: 
+        - pattern: new $STEG(...)
+        - metavariable-regex:
+            metavariable: $STEG
+            regex: (?i).*Steganography.*
+      # openstego
+      - pattern-regex: (['"`])java\s+\-jar.*\\openstego\.jar\s+embed
+      
 
     severity: WARNING

--- a/tests/analyzer/sourcecode/Steganography.java
+++ b/tests/analyzer/sourcecode/Steganography.java
@@ -140,6 +140,27 @@ public class Steganography {
     
         }
          
+        // github example
+        private void Steganography2 {
+            public static void main(String[] args) {
+                try {
+                    UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                // ruleid: maven-steganography
+                SwingUtilities.invokeLater(() -> new SteganographyGUI().setVisible(true));
+            }
+        }
+
+        // homemade example
+        // ruleid: maven-steganography
+        Runtime.getRuntime().exec("java -jar prog\openstego.jar embed -a randomlsb -mf secret.txt -cf wallpaper.png -sf test.png");
+        // ruleid: maven-steganography
+        String cmd = "java -jar code\openstego.jar embed -a randomlsb -mf secret.txt -cf wallpaper.png -sf test.png";
+        Runtime.getRuntime().exec(cmd);
+ 
+
 
     
 }

--- a/tests/analyzer/sourcecode/Steganography.java
+++ b/tests/analyzer/sourcecode/Steganography.java
@@ -94,6 +94,52 @@ public class Steganography {
             }
     
             System.out.println("Test complete");
+
+
         }
+
+
+        // stack overflow example
+        public static void steg(String[] args) throws Exception {
+            try {
+                BufferedImage coverImageText = ImageIO.read(new File("originalPic.png"));       
+                String s = "Java is a popular programming language, created in 1995.";
+                // ruleid: maven-steganography
+                coverImageText = Steganography.embedText(coverImageText, s);                                // embed the secret information
+                Steganography.extractText(ImageIO.read(new File("textEmbedded.png")), s.length()); // extract the secret information
+            } catch(IOException e) {        
+                System.out.print("Error: " + e);
+            }   
+        }
+
+        // github example
+        public void saveWallet(){
+            try {
+    
+                //writes the data to the stegno file
+                //finally, move the file to the output directory
+                // ruleid: maven-steganography
+                Steganography a = new Steganography(this.file, new File(this.directory.getAbsolutePath()+"\\Wallet_Image_"+this.file.getName()));
+                a.setText(this.EncryptedAddresses);
+                a.saveImage();
+    
+                //finall, create JSON file with all bitcoin addresses format { "0":"dgdgs", "1":"sdfsdf" }
+                String json = this.file.getName().substring(0, this.file.getName().lastIndexOf('.')) + ".json";
+                new OutputJSON(this.address.toString(), new File(this.directory.getAbsolutePath()+"\\Wallet_Image_"+json)).export();
+    
+    
+                //Clear static setting, for new addresses.. if not, it will contain previous addresses
+                this.address.delete(0, this.address.length());
+                EncryptedAddresses = "";
+    
+            } catch (Exception e){
+    
+                System.out.print(e);
+    
+            }
+    
+        }
+         
+
     
 }

--- a/tests/analyzer/sourcecode/Steganography.java
+++ b/tests/analyzer/sourcecode/Steganography.java
@@ -1,0 +1,99 @@
+import java.io.ByteArrayOutputStream;
+import io.github.galliumdata.adumbra.*;
+
+
+public class Steganography {
+    // from documnetation example
+    // Get the value of the bitmap column as a byte stream
+    let inStream = context.packet.getJavaStream("bitmap");
+    if (inStream === null) {
+        return;
+    }
+
+    // The hidden message
+    const now = new Date();
+    const message = "Retrieved by " + context.connectionContext.userName + 
+        " on " + now.getFullYear() + "/" + (now.getMonth()+1) + "/" + now.getDate();
+    const messageBytes = context.utils.getUTF8BytesForString(message);
+    const keyBytes = context.utils.getUTF8BytesForString("This is my secret key");
+
+    // Hide the message in the bitmap
+    const Encoder = Java.type("com.galliumdata.adumbra.Encoder");
+    const ByteArrayOutputStream = Java.type("java.io.ByteArrayOutputStream");
+    let outStream = new ByteArrayOutputStream();
+    let encoder = new Encoder(1);
+    // ruleid: maven-steganography
+    encoder.encode(inStream, outStream, "png", messageBytes, keyBytes);
+    context.packet.bitmap = outStream.toByteArray();
+
+
+
+    // github example
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            throw new RuntimeException("First argument must be \"encode\" or \"decode\"");
+        }
+
+        String arg0 = args[0].toLowerCase().trim();
+        if ("encode".equals(arg0)) {
+            if (args.length < 5) {
+                throw new RuntimeException("Parameters for encode must be: encode <input-file> <output-file> " +
+                        "<message> <key> [<format> [<sec-level>]]");
+            }
+
+            String format = null;
+            if (args.length >= 6) {
+                format = args[5];
+            }
+
+            int secLevel = 0;
+            if (args.length >= 7) {
+                try {
+                    secLevel = Integer.parseInt(args[6]);
+                }
+                catch(Exception ex) {
+                    throw new RuntimeException("Invalid value for parameter");
+                }
+            }
+            FileOutputStream fos = new FileOutputStream(args[2]);
+            String message = args[3];
+            String key = args[4];
+            Encoder encoder = new Encoder(secLevel);
+            FileInputStream inStr = new FileInputStream(args[1]);
+            // ruleid: maven-steganography
+            encoder.encode(inStr, fos,  format, message.getBytes(StandardCharsets.UTF_8), key.getBytes(StandardCharsets.UTF_8));
+            fos.close();
+        }
+
+        // another github example
+        @Test
+        public void test() throws Exception {
+    
+            ImageIO.setUseCache(false);
+    
+            loadTestCases();
+            for (TestCase tc: testCases) {
+                System.out.println("Testing: " + tc.inFile + " -> " + tc.outFile + " secLevel: " + tc.secLevel);
+                for (int i = 0; i < tc.numReps; i++) {
+                    long startTime = System.currentTimeMillis();
+                    Encoder encoder = new Encoder(tc.secLevel);
+                    FileInputStream inStr = new FileInputStream(tc.inFile);
+                    FileOutputStream fos = new FileOutputStream(tc.outFile);
+                    // ruleid:  maven-steganography
+                    encoder.encode(inStr, fos, tc.format, tc.message, tc.key);
+                    fos.close();
+                    System.out.println("Time for encoding: " + (System.currentTimeMillis() - startTime));
+    
+                    startTime = System.currentTimeMillis();
+                    Decoder decoder = new Decoder();
+                    FileInputStream inStr2 = new FileInputStream(tc.outFile);
+                    byte[] decoded = decoder.decode(inStr2, tc.key);
+                    System.out.println("Time for decoding: " + (System.currentTimeMillis() - startTime));
+                    assertArrayEquals(tc.message, decoded);
+                }
+            }
+    
+            System.out.println("Test complete");
+        }
+    
+}


### PR DESCRIPTION
Rule for detecting Steganography usage in java

Support detection for several libraries: adumbra, Steganography-in-Java, ImageHandle.Steganography, openstego and custom classes containing "Steganography" in their name

Example taken from GitHub to test the rule 