### PR TITLE
Maven/scanner - remote package download 

### DIFF
--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -1,8 +1,8 @@
 import logging
 import os
-import shutil
 import typing
 import xml.etree.ElementTree as ET
+import requests
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
@@ -10,6 +10,8 @@ from guarddog.scanners.scanner import PackageScanner
 from guarddog.utils.archives import safe_extract
 
 log = logging.getLogger("guarddog")
+
+MAVEN_CENTRAL_BASE_URL = "https://repo1.maven.org/maven2"
 
 
 class MavenPackageScanner(PackageScanner):
@@ -28,6 +30,12 @@ class MavenPackageScanner(PackageScanner):
         file_name += f".{extension}"
 
         return os.path.join(artifact_path, file_name)
+
+    def _get_maven_central_url(self, package_name: str, version: str, classifier: typing.Optional[str] = None,
+                               extension: str = "jar") -> str:
+        """Get the Maven Central URL for an artifact"""
+        artifact_path = self._get_path_for_artifact(package_name, version, classifier, extension)
+        return f"{MAVEN_CENTRAL_BASE_URL}/{artifact_path}"
 
     def _parse_pom(self, pom_path: str) -> dict:
         try:
@@ -51,7 +59,6 @@ class MavenPackageScanner(PackageScanner):
         artifact_id = find_text(root, "artifactId")
         version = find_text(root, "version")
 
-        # Inherit from parent
         parent = root.find(f"{{{namespace}}}parent" if namespace else "parent")
         if parent is not None:
             if not group_id:
@@ -71,48 +78,44 @@ class MavenPackageScanner(PackageScanner):
             }
         }
 
-    def _has_java_source_files(self, directory: str) -> bool:
-        """Check if directory contains Java source files directly"""
-        for root, dirs, files in os.walk(directory):
-            for file in files:
-                if file.endswith('.java'):
-                    return True
-        return False
-
     def download_package(self, package_name: str, directory: str, version: typing.Optional[str] = None) -> str:
         if version is None:
             raise ValueError("Version must be specified for Maven packages")
 
-        local_maven_repo = os.path.expanduser("~/.m2/repository")
         _, artifact_id = package_name.split(":")
 
-        # Try sources JAR first
-        sources_path_in_repo = self._get_path_for_artifact(package_name, version, classifier="sources", extension="jar")
-        full_sources_path = os.path.join(local_maven_repo, sources_path_in_repo)
+        sources_url = self._get_maven_central_url(package_name, version, classifier="sources", extension="jar")
+        regular_url = self._get_maven_central_url(package_name, version, classifier=None, extension="jar")
 
-        jar_to_extract = None
+        jar_to_download = None
         jar_type = None
 
-        if os.path.exists(full_sources_path):
-            jar_to_extract = full_sources_path
+        log.debug(f"Trying to download sources JAR from {sources_url}")
+        response = requests.head(sources_url)
+        if response.status_code == 200:
+            jar_to_download = sources_url
             jar_type = "sources"
             log.debug(f"Found sources JAR for {package_name}:{version}")
         else:
-            # Fallback to regular JAR
-            regular_path_in_repo = self._get_path_for_artifact(package_name, version, classifier=None, extension="jar")
-            full_regular_path = os.path.join(local_maven_repo, regular_path_in_repo)
-
-            if os.path.exists(full_regular_path):
-                jar_to_extract = full_regular_path
+            log.debug(f"Sources JAR not found, trying regular JAR from {regular_url}")
+            response = requests.head(regular_url)
+            if response.status_code == 200:
+                jar_to_download = regular_url
                 jar_type = "regular"
-                log.debug(f"Found regular JAR for {package_name}:{version} (sources not available)")
+                log.debug(f"Found regular JAR for {package_name}:{version}")
             else:
-                raise FileNotFoundError(f"Could not find JAR for {package_name}:{version} in local Maven repository. "
-                                        f"Looked for sources at {full_sources_path} and regular at {full_regular_path}")
+                raise FileNotFoundError(f"Could not find JAR for {package_name}:{version} on Maven Central. "
+                                        f"Checked sources at {sources_url} and regular at {regular_url}")
 
-        # Copy and extract the JAR
         destination_jar = os.path.join(directory, f"{artifact_id}-{version}-{jar_type}.jar")
-        shutil.copyfile(jar_to_extract, destination_jar)
+        log.debug(f"Downloading JAR from {jar_to_download} to {destination_jar}")
+        
+        response = requests.get(jar_to_download, stream=True)
+        response.raise_for_status()
+        
+        with open(destination_jar, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
 
         unzippedpath = os.path.join(directory, package_name.replace(":", "_"))
         safe_extract(destination_jar, unzippedpath)
@@ -125,84 +128,19 @@ class MavenPackageScanner(PackageScanner):
 
         extract_dir = self.download_package(package_name, directory, version)
 
-        local_maven_repo = os.path.expanduser("~/.m2/repository")
-        pom_path_in_repo = self._get_path_for_artifact(package_name, version, classifier=None, extension="pom")
-        full_pom_path = os.path.join(local_maven_repo, pom_path_in_repo)
+        pom_url = self._get_maven_central_url(package_name, version, classifier=None, extension="pom")
+        pom_path = os.path.join(directory, f"{package_name.replace(':', '_')}.pom")
+        
+        log.debug(f"Downloading POM from {pom_url} to {pom_path}")
+        response = requests.get(pom_url)
+        if response.status_code != 200:
+            raise FileNotFoundError(f"Could not find POM for {package_name}:{version} on Maven Central. "
+                                    f"URL: {pom_url}")
 
-        if not os.path.exists(full_pom_path):
-            raise FileNotFoundError(f"Could not find pom for {package_name}:{version} in local Maven repository. "
-                                    f"Looked for {full_pom_path}")
+        with open(pom_path, "w", encoding="utf-8") as f:
+            f.write(response.text)
 
-        package_info = self._parse_pom(full_pom_path)
+        package_info = self._parse_pom(pom_path)
         package_info.setdefault("info", {})["version"] = version
 
         return package_info, extract_dir
-
-    def get_local_package_info(self, path: str) -> tuple[dict, str]:
-        """
-        Handle two modes:
-        1. Directory with pom.xml and Java source files directly
-        2. Directory containing a JAR file to extract
-        """
-        # Mode 1: Directory with Java source files and pom.xml
-        pom_path = os.path.join(path, "pom.xml")
-        if os.path.exists(pom_path) and self._has_java_source_files(path):
-            log.debug(f"Found Java source files directly in {path}")
-            package_info = self._parse_pom(pom_path)
-            return package_info, path
-
-        # Mode 2: Directory contains a JAR file
-        jar_files = [f for f in os.listdir(path) if f.endswith('.jar')]
-        if jar_files:
-            # Use the first JAR file found
-            jar_file = jar_files[0]
-            jar_path = os.path.join(path, jar_file)
-
-            # Extract to a subdirectory
-            extract_dir = os.path.join(path, "extracted")
-            # Clear existing extract directory to avoid stale files
-            if os.path.exists(extract_dir):
-                shutil.rmtree(extract_dir)
-            os.makedirs(extract_dir)
-            safe_extract(jar_path, extract_dir)
-            log.debug(f"Extracted JAR {jar_file} to {extract_dir}")
-
-            # Look for pom.xml in extracted content or in the original directory
-            extracted_pom = os.path.join(extract_dir, "META-INF", "maven")
-            package_info = {}
-
-            # Try to find POM in META-INF/maven structure
-            if os.path.exists(extracted_pom):
-                for root, dirs, files in os.walk(extracted_pom):
-                    for file in files:
-                        if file == "pom.xml":
-                            pom_file_path = os.path.join(root, file)
-                            package_info = self._parse_pom(pom_file_path)
-                            break
-                    if package_info:
-                        break
-
-            # Fallback: check if there's a pom.xml in the original directory
-            if not package_info and os.path.exists(pom_path):
-                package_info = self._parse_pom(pom_path)
-
-            # If still no package info, create minimal info from JAR filename
-            if not package_info:
-                jar_name = os.path.splitext(jar_file)[0]
-                package_info = {
-                    "info": {
-                        "name": jar_name,
-                        "version": "unknown"
-                    }
-                }
-                log.warning(f"Could not find POM information for {jar_file}, using filename as package name")
-
-            return package_info, extract_dir
-
-        # Fallback: try just pom.xml without Java files (project directory)
-        if os.path.exists(pom_path):
-            log.debug(f"Found pom.xml in {path} but no Java source files")
-            package_info = self._parse_pom(pom_path)
-            return package_info, path
-
-        raise Exception(f"No pom.xml or JAR files found in {path}")

--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -14,6 +14,7 @@ from guarddog.utils.archives import safe_extract, is_supported_archive
 log = logging.getLogger("guarddog")
 
 MAVEN_CENTRAL_BASE_URL = "https://repo1.maven.org/maven2"
+CFR_JAR_PATH = "../cfr-0.152.jar"
 
 
 class MavenPackageScanner(PackageScanner):
@@ -33,11 +34,12 @@ class MavenPackageScanner(PackageScanner):
             * `version` (str): version of the package
             * `directory` (str): name of the dir to host the package. Created if does not exist
         Returns:
-            * `package_info` (dict): necessary metadata for analysis
-            * `path` (str): path to the local package:
-                - pom.xml
-                - decompressed/decompressed_jar
-                - decompiled/decompiled_java_files
+            * package_info (dict): necessary metadata for analysis
+                - `path` (str): path to the local package:
+                    - pom.xml
+                    - decompressed/decompressed_jar
+                    - decompiled/decompiled_java_files
+            * path to the decompiled sourcecode
         """
         if version is None:
             raise ValueError("Version must be specified for Maven packages")
@@ -66,7 +68,7 @@ class MavenPackageScanner(PackageScanner):
 
         # diff between retrieved and decompressed pom
         jar_pom: tuple[bool, str] | None = self.diff_pom(
-            directory, group_id, artifact_id, pom_path
+            decompressed_path, group_id, artifact_id, pom_path
         )
         if jar_pom:
             same, pom_jar_path = jar_pom
@@ -74,9 +76,15 @@ class MavenPackageScanner(PackageScanner):
                 log.debug("Same pom.xml in Maven and decompressed project!")
             else:
                 print("The 2 found pom.xml for the project differ.")
+                print(f"\t -pom retrived from Maven: {pom_path}")
+                print(f"\t -pom found in decompressed package: {pom_jar_path}")
                 pom_path = pom_jar_path
 
-        # analyse resulting files
+        # package_info
+        package_info: dict = self.get_package_info(
+            pom_path, decompressed_path, decompiled_path, group_id, artifact_id, version
+        )
+        return package_info, directory
 
     def download_package(
         self, group_id: str, artifact_id: str, directory: str, version: str
@@ -100,6 +108,7 @@ class MavenPackageScanner(PackageScanner):
         pom_url = f"{base_url}/{artifact_id}-{version}.pom"
 
         # destination files
+        log.debug(f"Downloading package in {directory} ")
         os.makedirs(directory, exist_ok=True)
         jar_path = os.path.join(directory, f"{artifact_id}-{version}.jar")
         pom_path = os.path.join(directory, "pom.xml")
@@ -153,37 +162,37 @@ class MavenPackageScanner(PackageScanner):
             - If pom found, returns the pom path
         """
         if not os.path.exists(pom_path):
-            return
+            return None
         jar_pom = self.find_pom(path, groupId, artifactId)
         if jar_pom:
             return filecmp.cmp(jar_pom, pom_path), jar_pom
         else:
-            return
+            return None
 
-    def decompile_jar(self, jar_path: str, dest_path: str, cfr_jar_path: str):
+    def decompile_jar(self, jar_path: str, dest_path: str):
         """
         Decompiles the .jar file using CFR decompiler.
         Args:
             - `jar_path` (str): path of the .jar to decompile
             - `dest_path` (str): path of the destination folder
             to store the resulting .class files
-            - `cfr_jar_path` (str): Path to cfr.jar decompiler
         """
         if not os.path.isfile(jar_path):
             raise FileNotFoundError(f"JAR file not found: {jar_path}")
-        if not os.path.isfile(cfr_jar_path):
-            raise FileNotFoundError(f"CFR decompiler not found: {cfr_jar_path}")
+        if not os.path.isfile(CFR_JAR_PATH):
+            raise FileNotFoundError(f"CFR jar file not found: {CFR_JAR_PATH}")
 
         os.makedirs(dest_path, exist_ok=True)
 
         command = [
             "java",
             "-jar",
-            cfr_jar_path,
+            CFR_JAR_PATH,
             jar_path,
             "--outputdir",
             dest_path,
             "--silent",
+            "true",
         ]
 
         try:
@@ -191,3 +200,62 @@ class MavenPackageScanner(PackageScanner):
             log.debug(f"Decompiled JAR written to: {os.path.abspath(dest_path)}")
         except subprocess.CalledProcessError as e:
             print(f"Error running CFR: {e}")
+
+    def get_package_info(
+        self,
+        pom_path: str,
+        decompressed_path: str,
+        decompiled_path: str,
+        group_id: str,
+        artifact_id: str,
+        version: str,
+    ) -> dict:
+        """
+        Returns a dict with package info from args and retrived from parsing pom.xml
+        "info"
+            - "groupid"
+            - "artifactid"
+            - "version"
+            - "email": list[str]
+        "path"
+            - "pom_path"
+            - "decompressed_path"
+            - "decompiled_path"
+        """
+        emails = []
+        log.debug(f"Parsing pom {pom_path}")
+        if not os.path.isfile(pom_path):
+            log.warning(f"WARNING: {pom_path} does not exist.")
+        try:
+            tree = ET.parse(pom_path)
+            root = tree.getroot()
+
+            # Detect namespace if present
+            namespace = ""
+            if "}" in root.tag:
+                namespace = root.tag.split("}")[0].strip("{")
+            ns = {"mvn": namespace} if namespace else {}
+
+            for dev in root.findall(".//mvn:developer", ns):
+                email = dev.find("mvn:email", ns)
+                if email is not None and email.text:
+                    emails.append(email.text.strip())
+
+        except ET.ParseError as e:
+            log.warning(f"Failed to parse POM: {pom_path}, error: {e}")
+        except Exception as e:
+            log.warning(f"Unexpected error parsing POM: {e}")
+
+        return {
+            "info": {
+                "groupid": group_id,
+                "artifactid": artifact_id,
+                "version": version,
+                "email": emails,
+            },
+            "path": {
+                "pom_path": pom_path,
+                "decompressed_path": decompressed_path,
+                "decompiled_path": decompiled_path,
+            },
+        }

--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -92,7 +92,7 @@ class MavenPackageScanner(PackageScanner):
             pom_path, decompressed_path, decompiled_path, group_id, artifact_id, version
         )
         log.debug(f"Package info: {package_info}")
-        return package_info, directory
+        return package_info, decompiled_path
 
     def download_package(
         self, group_id: str, artifact_id: str, directory: str, version: str

--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -3,6 +3,7 @@ import os
 import typing
 import xml.etree.ElementTree as ET
 import requests
+import filecmp
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
@@ -21,22 +22,56 @@ class MavenPackageScanner(PackageScanner):
     def download_and_get_package_info(
         self, directory: str, package_name: str, version=None
     ) -> typing.Tuple[dict, str]:
+        """
+        Downloads the package from Maven Central (.jar)
+        Downloads the corresponding pom file
+        Decompressed the .jar
+        Decompile the .jar
+        Args:
+            * `package_name` (str): group_id:artifact_id of the package on Maven
+            * `version` (str): version of the package
+            * `directory` (str): name of the dir to host the package. Created if does not exist
+        Returns:
+            * `package_info` (dict): necessary metadata for analysis
+            * `path` (str): path to the local package
+        """
         if version is None:
             raise ValueError("Version must be specified for Maven packages")
+        try:
+            group_id, artifact_id = package_name.split(":")
+        except ValueError:
+            raise Exception(
+                f"Invalid package format: '{package_name}'. Expected 'groupId:artifactId'"
+            )
         if not directory:
-            directory = package_name.split(":")[-1]
+            directory = artifact_id
 
-        jar_path, pom_path = self.download_package(package_name, directory, version)
+        jar_path, pom_path = self.download_package(
+            group_id, artifact_id, directory, version
+        )
+
         # decompress jar
         if is_supported_archive(jar_path):
             log.debug(f"Extracting {jar_path} into {directory}...")
             safe_extract(source_archive=jar_path, target_directory=directory)
-            os.remove(jar_path)
+            # os.remove(jar_path)
+
         # decompile jar
+
+        # diff between retrieved and decompressed pom
+        jar_pom: tuple[bool, str] | None = self.diff_pom()
+        if jar_pom:
+            same, pom_jar_path = jar_pom
+            if same:
+                log.debug("Same pom.xml in Maven and decompressed project!")
+            else:
+                print("The 2 found pom.xml for the project differ.")
+                pom_path = pom_jar_path
+
         # analyse resulting files
 
     def download_package(
-        package_name: str, directory: str, version: str
+        self, group_id: str, artifact_id: str, directory: str, version: str
     ) -> tuple[str, str]:
         """
         Downloads the Maven package .jar and pom for the specified version
@@ -48,12 +83,6 @@ class MavenPackageScanner(PackageScanner):
         Returns:
             Paths of the downloded jar file and the corresponding downloaded pom.xml
         """
-        try:
-            group_id, artifact_id = package_name.split(":")
-        except ValueError:
-            raise Exception(
-                f"Invalid package format: '{package_name}'. Expected 'groupId:artifactId'"
-            )
 
         group_path = group_id.replace(".", "/")
 
@@ -85,3 +114,40 @@ class MavenPackageScanner(PackageScanner):
 
         except Exception as e:
             raise Exception(f"Error retrieving Maven package: {e}")
+
+    def find_pom(self, path: str, groupId: str, artifactId: str) -> str | None:
+        """
+        Finds the pom.xml in the package at `path` if exists
+        """
+        pom_path = os.path.join(
+            path, "META-INF", "maven", groupId, artifactId, "pom.xml"
+        )
+        if os.path.exists(pom_path):
+            return pom_path
+        else:
+            print(f"No pom.xml found at {pom_path}")
+            return None
+
+    def diff_pom(
+        self, path: str, groupId: str, artifactId: str, pom_path: str
+    ) -> tuple[bool, str] | None:
+        """
+        Args
+            - `path` (str): path to the decompressed project
+            - `groupId` (str): groupid of the package
+            - `artifactId` (str): artifact id of the package
+            - `pom_path` (str): pom.xml path to compare the project pom to
+
+        Compare both poms and returns a bool
+        Returns:
+            - True if same poms
+            - False if not
+            - If pom found, returns the pom path
+        """
+        if not os.path.exists(pom_path):
+            return
+        jar_pom = self.find_pom(path, groupId, artifactId)
+        if jar_pom:
+            return filecmp.cmp(jar_pom, pom_path), jar_pom
+        else:
+            return

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -26,7 +26,7 @@ def is_supported_archive(path: str) -> bool:
         return any(path.endswith(ext) for ext in tar_exts)
 
     def is_zip_archive(path: str) -> bool:
-        return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg", ".jar"])
+        return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])
 
     return is_tar_archive(path) or is_zip_archive(path)
 

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -26,7 +26,7 @@ def is_supported_archive(path: str) -> bool:
         return any(path.endswith(ext) for ext in tar_exts)
 
     def is_zip_archive(path: str) -> bool:
-        return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])
+        return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg", ".jar"])
 
     return is_tar_archive(path) or is_zip_archive(path)
 


### PR DESCRIPTION
Scanner for maven remote packages
- downloads remote package from Maven Central: .jar file and pom.xml
- decompress the .jar file
- decompile the jar with CFR java decompiler
- compare downloaded pom.xml with extracted pom.xml if exists 
- build package_info dict: package coordinates, paths to decompressed and decompiled packages, pom, maintainer's email if exists 
- cli usage: _guarddog maven scan groupeId:artifactId --version v_ (version is mandatory)

This class is called whenever a non local package is called 
It then runs metadata scanners and sourcecode scanners on the resulting decompiled project 