### PR TITLE
Support local jar

### DIFF
--- a/guarddog/analyzer/sourcecode/maven/dangerous_pom_xml.py
+++ b/guarddog/analyzer/sourcecode/maven/dangerous_pom_xml.py
@@ -273,9 +273,9 @@ class MavenDangerousPomXML(Detector):
             artifact_id = plugin.find("mvn:artifactId", NAMESPACE)
             plugin_id = self.get_text(artifact_id) or "(unknown-plugin)"
 
-            early_phases = []
-            tags_found = []
             for execution in plugin.findall(".//mvn:execution", NAMESPACE):
+                early_phases = []
+                tags_found = []
                 phase = False
                 has_susp_tag = False
                 #  <execution> blocks bound to early phase

--- a/guarddog/analyzer/sourcecode/maven/dangerous_pom_xml.py
+++ b/guarddog/analyzer/sourcecode/maven/dangerous_pom_xml.py
@@ -361,4 +361,5 @@ class MavenDangerousPomXML(Detector):
                 suspicious = True
                 suspicious_commands.append(cmd)
                 log.debug("Suspicious command in <argLine> (curl, wget, sh...)")
+        suspicious_commands = list(set(suspicious_commands))
         return suspicious, suspicious_commands

--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
 from guarddog.scanners.scanner import PackageScanner
-from guarddog.utils.archives import decompile_jar, extract_jar
+from guarddog.utils.archives import decompile_jar, extract_jar, find_pom
 
 log = logging.getLogger("guarddog")
 
@@ -192,6 +192,8 @@ class MavenPackageScanner(PackageScanner):
         if not os.path.exists(pom_path):
             return None
         jar_pom = self.find_pom(path, groupId, artifactId)
+        if not jar_pom: # search recursively
+            jar_pom = find_pom(path)
         if jar_pom:
             return filecmp.cmp(jar_pom, pom_path), jar_pom
         else:

--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -192,7 +192,7 @@ class MavenPackageScanner(PackageScanner):
         if not os.path.exists(pom_path):
             return None
         jar_pom = self.find_pom(path, groupId, artifactId)
-        if not jar_pom: # search recursively
+        if not jar_pom:  # search recursively
             jar_pom = find_pom(path)
         if jar_pom:
             return filecmp.cmp(jar_pom, pom_path), jar_pom

--- a/guarddog/scanners/maven_package_scanner.py
+++ b/guarddog/scanners/maven_package_scanner.py
@@ -1,26 +1,21 @@
 import logging
 import os
-import subprocess
 import typing
 import xml.etree.ElementTree as ET
 import requests
 import filecmp
-import zipfile
 import shutil
 from urllib.parse import urlparse
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
 from guarddog.scanners.scanner import PackageScanner
+from guarddog.utils.archives import decompile_jar, extract_jar
 
 log = logging.getLogger("guarddog")
 
 MAVEN_CENTRAL_BASE_URL = "https://repo1.maven.org/maven2"
 TRUSTED_DOMAINS = {"repo1.maven.org", "search.maven.org"}
-CFR_JAR_PATH = os.environ.get(
-    "CFR_JAR_PATH",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../cfr-0.152.jar")),
-)
 
 
 class MavenPackageScanner(PackageScanner):
@@ -67,7 +62,7 @@ class MavenPackageScanner(PackageScanner):
         if jar_path.endswith(".jar"):
             log.debug(f"Extracting {jar_path} into {directory}...")
             decompressed_path = os.path.join(directory, "decompressed")
-            self.extract_jar(jar_path, decompressed_path)
+            extract_jar(jar_path, decompressed_path)
         else:
             log.debug(f"Could not extract {jar_path}")
         if (
@@ -81,7 +76,7 @@ class MavenPackageScanner(PackageScanner):
 
         # decompile jar
         decompiled_path: str = os.path.join(directory, "decompiled")
-        self.decompile_jar(jar_path, decompiled_path)
+        decompile_jar(jar_path, decompiled_path)
 
         # diff between retrieved and decompressed pom
         jar_pom: tuple[bool, str] | None = self.diff_pom(
@@ -161,30 +156,6 @@ class MavenPackageScanner(PackageScanner):
         except Exception as e:
             raise Exception(f"Error retrieving Maven package: {e}")
 
-    def extract_jar(self, jar_path: str, output_dir: str):
-        """
-        Extract a jar archive file with zipfile
-        - `jar_path` (str): path to the jar to extract
-        - `output_dir` (str): directory to decompress the jar to
-        """
-        with zipfile.ZipFile(jar_path, "r") as jar:
-            log.debug("Extracting jar package...")
-            output_dir_abs = os.path.abspath(output_dir)
-            for file in jar.namelist():
-                # resolve paths and removes ../
-                safe_path = os.path.abspath(os.path.join(output_dir, file))
-                # ensure safe_path in the output dir
-                if os.path.commonpath([output_dir_abs, safe_path]) != output_dir_abs:
-                    log.warning(f"Skipping potentially unsafe file: {file}")
-                    continue
-                if file.endswith("/"):  # It's a directory
-                    os.makedirs(safe_path, exist_ok=True)
-                    continue
-                os.makedirs(os.path.dirname(safe_path), exist_ok=True)
-                with open(safe_path, "wb") as f:
-                    f.write(jar.read(file))
-        log.debug(f"extracted to {output_dir}")
-
     def find_pom(self, path: str, groupId: str, artifactId: str) -> str | None:
         """
         Finds the pom.xml in the package at `path` if exists
@@ -225,47 +196,6 @@ class MavenPackageScanner(PackageScanner):
             return filecmp.cmp(jar_pom, pom_path), jar_pom
         else:
             return None
-
-    def is_safe_path(self, path: str) -> bool:
-        """Basic path safety check to avoid traversal or injection."""
-        return os.path.isabs(path) or not (".." in path or path.startswith(("/", "\\")))
-
-    def is_jar_file(self, path: str) -> bool:
-        return path.endswith(".jar") and os.path.isfile(path)
-
-    def decompile_jar(self, jar_path: str, dest_path: str):
-        """
-        Decompiles the .jar file using CFR decompiler.
-        Args:
-            - `jar_path` (str): path of the .jar to decompile
-            - `dest_path` (str): path of the destination folder
-            to store the resulting .class files
-        """
-        if not self.is_safe_path(jar_path) or not self.is_jar_file(jar_path):
-            raise ValueError(f"Invalid JAR path: {jar_path}")
-        if not os.path.isfile(CFR_JAR_PATH):
-            raise FileNotFoundError(f"CFR jar file not found: {CFR_JAR_PATH}")
-        if not self.is_safe_path(dest_path):
-            raise ValueError(f"Invalid destination path: {dest_path}")
-
-        os.makedirs(dest_path, exist_ok=True)
-
-        command = [
-            "java",
-            "-jar",
-            CFR_JAR_PATH,
-            jar_path,
-            "--outputdir",
-            dest_path,
-            "--silent",
-            "true",
-        ]
-
-        try:
-            subprocess.run(command, check=True)
-            log.debug(f"Decompiled JAR written to: {os.path.abspath(dest_path)}")
-        except subprocess.CalledProcessError as e:
-            log.error(f"Error running CFR: {e}")
 
     def get_package_info(
         self,

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -135,8 +135,8 @@ def extract_and_decompile_jar(jar_path: str, output_dir: str):
     if not pom_path:
         log.error(f"No pom.xml found in the project {jar_path}")
     else:
-        log.debug("Successfully found the pom.xml.")
-        shutil.move(pom_path, decompiled_path)
+        log.debug("Successfully found the pom.xml in the archive.")
+        shutil.move(pom_path, output_dir)
 
 
 def find_pom(decompressed_path: str) -> str:

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -95,7 +95,7 @@ def extract_and_decompile_jar(jar_path: str, output_dir: str):
     """
     Decompress the jar file into output_dir/decompressed
     Decompile the java bytecode in output_dir/decompiled
-    Moves the pom.xml if present to output_dir/decompiled/pom.xml
+    Moves the pom.xml if present to output_dir/pom.xml
     """
     if not os.path.isfile(jar_path) or not jar_path.endswith(".jar"):
         raise ValueError(f"Invalid jar file provided at {jar_path}")

--- a/guarddog/utils/exceptions.py
+++ b/guarddog/utils/exceptions.py
@@ -7,3 +7,17 @@ class PomXmlValidationError(Exception):
 
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class ExtractionError(Exception):
+    """Raised when extracting an archive fails."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class DecompilationError(Exception):
+    """Raised when decompiling a .jar archive fails."""
+
+    def __init__(self, message: str):
+        super().__init__(message)


### PR DESCRIPTION
Supporting local jar files analysis: 

if path to local jar provided: 
- decompresses the jar
- decompiles the jar 
- finds the pom.xml recursively
- runs Semgrep + Yara + python scripts for sourcecode analysis 

Adding scripts for jar decompression, jar decompilation, pom.xml recursive search in utils/achives and using it also in download packages. 

Better error handling with custom exceptions for decompression and decompilation.

In download package, recursive search of pom.xml if none found in conventional path in jar.

corrections on duplicates in pom xml analysis.
