### PR TITLE
correction of release-zero which was not working

### DIFF
--- a/guarddog/analyzer/metadata/maven/release_zero.py
+++ b/guarddog/analyzer/metadata/maven/release_zero.py
@@ -11,7 +11,7 @@ log = logging.getLogger("guarddog")
 
 
 class MavenReleaseZeroDetector(ReleaseZeroDetector):
-    def detect(self, package_info, path: Optional[str] = None, name: Optional[str] = None,
+    def detect(self, package_info: dict, path: Optional[str] = None, name: Optional[str] = None,
                version: Optional[str] = None) -> tuple[bool, str]:
         """
         Detects if a Maven package's latest version is 0.0.0 or 0.0
@@ -27,7 +27,7 @@ class MavenReleaseZeroDetector(ReleaseZeroDetector):
         """
         log.debug(f"Running zero version heuristic on Maven package {name} version {version}")
 
-        latest_version = package_info.get("version", "")
+        latest_version, _ = package_info.get("info", {}).get("latest_version")
 
-        return (latest_version in ["0.0.0", "0.0"],
+        return (latest_version in ["0.0.0", "0.0", "0"],
                 ReleaseZeroDetector.MESSAGE_TEMPLATE % latest_version)


### PR DESCRIPTION
This is a correction of the non working rule release-zero. 

This metadata rule detects when a remote packages has its latest release to 0.0 (which is sketchy) 

 